### PR TITLE
fix missing credentials.go file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ cover.out
 
 /package
 
-credentials.*
+credentials.txt

--- a/pkg/clients/credentials.go
+++ b/pkg/clients/credentials.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+// Credentials is a common credential format used by various Packet Kubernetes
+// providers
+type Credentials struct {
+	APIKey     string `json:"apiKey"`
+	ProjectID  string `json:"projectID"`
+	FacilityID string `json:"facilityID"`
+}
+
+// Using these constants causes Credential methods to return the credential
+// configured values
+const (
+	CredentialAPIKey     = ""
+	CredentialProjectID  = ""
+	CredentialFacilityID = ""
+)
+
+// DefaultGetter provides setters for common Packet client properties
+type DefaultGetter interface {
+	GetProjectID(string) string
+	GetFacilityID(string) string
+}
+
+// DefaultSetter provides setters for common Packet client properties
+type DefaultSetter interface {
+	SetProjectID(string)
+	SetFacilityID(string)
+}
+
+// Defaulter provides getter and setters for common Packet client properties
+type Defaulter interface {
+	DefaultGetter
+	DefaultSetter
+}
+
+// GetProjectID returns the supplied ProjectID or the ProjectID included with
+// the Client credentials (if any)
+func (c *Credentials) GetProjectID(projectID string) string {
+	if projectID != "" {
+		return projectID
+	}
+	return c.ProjectID
+}
+
+// GetFacilityID returns the supplied FacilityID or the FacilityID included with
+// the Client credentials (if any)
+func (c *Credentials) GetFacilityID(facilityID string) string {
+	if facilityID != "" {
+		return facilityID
+	}
+	return c.FacilityID
+}
+
+// GetAPIKey returns the supplied APIKey or the APIKey included with the
+// Client credentials (if any)
+func (c *Credentials) GetAPIKey(apiKey string) string {
+	if apiKey != "" {
+		return apiKey
+	}
+	return c.APIKey
+}
+
+// SetProjectID sets the default ProjectID for the client
+func (c *Credentials) SetProjectID(projectID string) {
+	c.ProjectID = projectID
+}
+
+// SetFacilityID sets the default FacilityID for the client
+func (c *Credentials) SetFacilityID(facilityID string) {
+	c.FacilityID = facilityID
+}
+
+// SetAPIKey sets the default APIKey for the client
+func (c *Credentials) SetAPIKey(apiKey string) {
+	c.APIKey = apiKey
+}
+
+// LateInitializeStringPtr returns `from` if `in` is empty and in other cases it
+// returns `in`.
+func LateInitializeStringPtr(in *string, from *string) *string {
+	if in == nil {
+		return from
+	}
+	return in
+}
+
+// LateInitializeString returns `from` if `in` is empty and in other cases it
+// returns `in`.
+func LateInitializeString(in string, from *string) string {
+	if in == "" && from != nil {
+		return *from
+	}
+	return in
+}
+
+// LateInitializeBoolPtr returns in if it's non-nil, otherwise returns from
+func LateInitializeBoolPtr(in *bool, from *bool) *bool {
+	if in != nil {
+		return in
+	}
+	return from
+}
+
+// LateInitializeIntPtr returns in if it's non-nil, otherwise returns from
+func LateInitializeIntPtr(in *int, from *int) *int {
+	if in != nil {
+		return in
+	}
+	return from
+}


### PR DESCRIPTION
### Description of your changes

The project does not compile because credentials.go only lives on my laptop.  This would have been caught by #6 

Adds the missing files and updates the .gitignore to only prevent credentials.txt (not credentials.go 😅 ).

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the [package resources documentation] and [`app.yaml`] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/packethost/crossplane-provider-packet/blob/master/config/package/manifests/app.yaml
[package resources documentation]: https://github.com/packethost/crossplane-provider-packet/blob/master/config/package/manifests/resources
