### PR TITLE
dont test builds and charts on markdown changes

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -1,6 +1,9 @@
 name: Install Provider
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   install-provider:


### PR DESCRIPTION
Initially attempted to skip build tests on .md changes in this PR: https://github.com/packethost/crossplane-provider-equinix-metal/pull/42

The rule provided in this PR was either ignored because the rule was included in a PR from a fork, or it doesn't work.

I'm going with the former.