### PR TITLE
Update crds.clean target to run after generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ crds.clean:
 	@find $(CRD_DIR) -name *.yaml.sed -delete || $(FAIL)
 	@$(OK) cleaned generated CRDs
 
-generate.run: crds.clean
+generate.done: crds.clean
 
 # integration tests
 e2e.run: test-integration

--- a/package/crds/metal.equinix.com_providerconfigs.yaml
+++ b/package/crds/metal.equinix.com_providerconfigs.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/metal.equinix.com_providerconfigusages.yaml
+++ b/package/crds/metal.equinix.com_providerconfigusages.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/ports.metal.equinix.com_assignments.yaml
+++ b/package/crds/ports.metal.equinix.com_assignments.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/server.metal.equinix.com_devices.yaml
+++ b/package/crds/server.metal.equinix.com_devices.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/vlan.metal.equinix.com_virtualnetworks.yaml
+++ b/package/crds/vlan.metal.equinix.com_virtualnetworks.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through the Crossplane contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

A recent update (https://github.com/upbound/build/commit/e9d1c75a941037e129109d4ebf086b4d8758a492#diff-559fcaffbb451b2171c3fc9d553af26a862572e94aa36a716d7ee326a224fee8) in the `build` submodule caused `crds.clean` to run before generation instead of after. This updates to run it after so that its changes are not overwritten.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
