### PR TITLE
ignore vlan attachment API responses "422 Virtual network foo already…"

### DIFF
--- a/apis/vlan/v1alpha1/virtualnetwork_types.go
+++ b/apis/vlan/v1alpha1/virtualnetwork_types.go
@@ -39,8 +39,7 @@ type VirtualNetworkStatus struct {
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.atProvider.id"
-// +kubebuilder:printcolumn:name="HOSTNAME",type="string",JSONPath=".spec.forProvider.hostname"
-// +kubebuilder:printcolumn:name="FACILITY",type="string",JSONPath=".status.atProvider.facility"
+// +kubebuilder:printcolumn:name="FACILITY",type="string",JSONPath=".status.atProvider.facilityCode"
 // +kubebuilder:printcolumn:name="RECLAIM-POLICY",type="string",JSONPath=".spec.reclaimPolicy"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
@@ -69,8 +68,11 @@ type VirtualNetworkList struct {
 // LateInitialization should update the parameter after creation.
 type VirtualNetworkParameters struct {
 	// +immutable
-	// +required
-	Facility string `json:"facility"`
+	// +optional
+	Facility string `json:"facility,omitempty"`
+
+	// +optional
+	Metro string `json:"metro,omitempty"`
 
 	// +optional
 	Description *string `json:"description,omitempty"`
@@ -82,6 +84,6 @@ type VirtualNetworkObservation struct {
 	ID           string       `json:"id"`
 	Href         string       `json:"href,omitempty"`
 	VXLAN        int          `json:"vxlan,omitempty"`
-	FacilityCode string       `json:"facility_code,omitempty"`
+	FacilityCode string       `json:"facilityCode,omitempty"`
 	CreatedAt    *metav1.Time `json:"createdAt,omitempty"`
 }

--- a/package/crds/vlan.metal.equinix.com_virtualnetworks.yaml
+++ b/package/crds/vlan.metal.equinix.com_virtualnetworks.yaml
@@ -16,10 +16,7 @@ spec:
   - JSONPath: .status.atProvider.id
     name: ID
     type: string
-  - JSONPath: .spec.forProvider.hostname
-    name: HOSTNAME
-    type: string
-  - JSONPath: .status.atProvider.facility
+  - JSONPath: .status.atProvider.facilityCode
     name: FACILITY
     type: string
   - JSONPath: .spec.reclaimPolicy
@@ -69,8 +66,8 @@ spec:
                   type: string
                 facility:
                   type: string
-              required:
-              - facility
+                metro:
+                  type: string
               type: object
             providerConfigRef:
               description: ProviderConfigReference specifies how the provider that will be used to create, observe, update, and delete this managed resource should be configured.
@@ -115,7 +112,7 @@ spec:
                 createdAt:
                   format: date-time
                   type: string
-                facility_code:
+                facilityCode:
                   type: string
                 href:
                   type: string

--- a/pkg/clients/vlan/virtualnetwork.go
+++ b/pkg/clients/vlan/virtualnetwork.go
@@ -76,6 +76,7 @@ func NewClient(ctx context.Context, config *clients.Credentials) (ClientWithDefa
 func CreateFromVirtualNetwork(d *v1alpha1.VirtualNetwork, projectID string) *packngo.VirtualNetworkCreateRequest {
 	return &packngo.VirtualNetworkCreateRequest{
 		Facility:    d.Spec.ForProvider.Facility,
+		Metro:       d.Spec.ForProvider.Metro,
 		Description: emptyIfNil(d.Spec.ForProvider.Description),
 		ProjectID:   projectID,
 	}

--- a/pkg/controller/ports/assignment/managed.go
+++ b/pkg/controller/ports/assignment/managed.go
@@ -18,7 +18,7 @@ package assignment
 
 import (
 	"context"
-	"strings"
+	"path"
 
 	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
@@ -127,7 +127,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	for _, net := range port.AttachedVirtualNetworks {
-		if strings.TrimPrefix(net.Href, "/virtual-networks/") == a.Spec.ForProvider.VirtualNetworkID {
+		if path.Base(net.Href) == a.Spec.ForProvider.VirtualNetworkID {
 			a.Status.SetConditions(xpv1.Available())
 			o.ResourceExists = true
 		}

--- a/pkg/controller/ports/assignment/managed.go
+++ b/pkg/controller/ports/assignment/managed.go
@@ -144,7 +144,7 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 	a.Status.SetConditions(xpv1.Creating())
 	_, _, err := e.client.Assign(&packngo.PortAssignRequest{PortID: meta.GetExternalName(a), VirtualNetworkID: a.Spec.ForProvider.VirtualNetworkID})
-	return managed.ExternalCreation{}, errors.Wrap(err, errCreateAssignment)
+	return managed.ExternalCreation{}, errors.Wrap(resource.Ignore(packetclient.IsAlreadyDone, err), errCreateAssignment)
 }
 
 func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
@@ -159,5 +159,5 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 	a.SetConditions(xpv1.Deleting())
 	_, _, err := e.client.Unassign(&packngo.PortAssignRequest{PortID: meta.GetExternalName(a), VirtualNetworkID: a.Spec.ForProvider.VirtualNetworkID})
-	return errors.Wrap(resource.Ignore(packetclient.IsNotFound, err), errDeleteAssignment)
+	return errors.Wrap(resource.IgnoreAny(err, packetclient.IsNotFound, packetclient.IsAlreadyDone), errDeleteAssignment)
 }


### PR DESCRIPTION
### Description of your changes

During conformance testing, attachment resources would reach un unready state, despite being ready.

```
vents:
  Type     Reason                           Age                    From                                        Message
  ----     ------                           ----                   ----                                        -------
  Warning  CannotResolveResourceReferences  2m9s (x10 over 2m11s)  managed/assignment.ports.metal.equinix.com  cannot resolve references: referenced field was empty (referenced resource may not yet be ready)
  Warning  CannotCreateExternalResource     119s (x3 over 2m6s)    managed/assignment.ports.metal.equinix.com  cannot create Assignment: POST https://api.equinix.com/metal/v1/ports/7f67f7da-8302-4b5c-afd2-df0babc02208/assign: 422 still bonded
  Normal   CreatedExternalResource          81s                    managed/assignment.ports.metal.equinix.com  Successfully requested creation of external resource
  Warning  CannotCreateExternalResource     39s (x3 over 80s)      managed/assignment.ports.metal.equinix.com  cannot create Assignment: POST https://api.equinix.com/metal/v1/ports/7f67f7da-8302-4b5c-afd2-df0babc02208/assign: 422 Virtual network 1182 already assigned
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #61 
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
