### PR TITLE
treat 404 on device port lookups as a deleted port attachment

### DIFF
--- a/pkg/controller/ports/assignment/managed.go
+++ b/pkg/controller/ports/assignment/managed.go
@@ -115,7 +115,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	// Observe port
 	port, err := e.client.GetPortByName(a.Spec.ForProvider.DeviceID, a.Spec.ForProvider.Name)
 	if packetclient.IsNotFound(err) {
-		return managed.ExternalObservation{}, errors.New("port does not exist")
+		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetPort)


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through the Crossplane contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->
Handles the condition where a VLAN port attachment can not be deleted because the device/port is already deleted.
```
### Description of your changes
  Warning  CannotObserveExternalResource    7s (x15 over 90s)   managed/assignment.ports.metal.equinix.com  port does not exist
```
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes #63
### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
